### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,46 +11,6 @@ jobs:
 
     name: Build and test
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: kafkaesque_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      kafka:
-        image: wurstmeister/kafka
-        env:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-        ports:
-          - 9092:9092
-        depends-on:
-          - zookeeper
-        options: >-
-          --health-cmd "nc -z localhost 9092"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      zookeeper:
-        image: wurstmeister/zookeeper
-        ports:
-          - 2181:2181
-        options: >-
-          --health-cmd "echo stat | nc localhost 2181 | grep Mode"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
     - uses: actions/checkout@v3
     - uses: erlef/setup-beam@v1
@@ -63,6 +23,26 @@ jobs:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
+    - name: Start supporting services
+      run: docker compose --profile with-postgres up -d
+    - name: Ensure Schema Registry is started
+      # Copied from: https://github.com/happening-oss/kafka-client/blob/develop/.github/workflows/ci.yml
+      run: |
+        # give up after 60 seconds
+        max_wait_time=60
+
+        # Use a loop to check if Schema Registry is ready
+        start_time=$(date +%s)
+        until docker compose logs schema-registry | grep -q "started"; do
+          current_time=$(date +%s)
+          elapsed_time=$((current_time - start_time))
+          if [ "$elapsed_time" -ge "$max_wait_time" ]; then
+            echo "Schema Registry did not start within the specified timeout."
+            exit 1  # Exit the workflow with an error
+          fi
+
+          sleep 5
+        done
     - name: Install dependencies
       run: mix deps.get
     - name: Setup Database

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,7 +2,7 @@ name: Build and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix_ci ]
   pull_request:
     branches: [ master ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+---
+version: '3'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: kafkaesque_test
+    ports:
+      - 5432:5432
+    profiles: ["with-postgres"]
+  kafka:
+    image: confluentinc/cp-kafka:7.5.1
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:29093
+      KAFKA_LISTENERS: PLAINTEXT://kafka:29092,CONTROLLER://localhost:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.5.1
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:29092
+      SCHEMA_REGISTRY_HOST_NAME: localhost
+    ports:
+      - 8081:8081
+    depends_on:
+      - kafka

--- a/test/kafkaesque/integration_test.exs
+++ b/test/kafkaesque/integration_test.exs
@@ -37,7 +37,7 @@ defmodule Kafkaesque.IntegrationTest do
     assert message.state == :pending
 
     # Could perform some synchronization to avoid sleeping
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     message2 = Repo.reload(message)
 

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -35,8 +35,10 @@ defmodule Kafkaesque.Test.Helpers do
       }
     ]
 
-    _ = :brod.create_topics([{"localhost", 9092}], topic_configs, %{timeout: 15_000})
-
-    :ok
+    case :brod.create_topics([{"localhost", 9092}], topic_configs, %{timeout: 15_000}) do
+      :ok -> :ok
+      {:error, :topic_already_exists} -> :ok
+      resp -> raise "Couldn't create topics - :brod.create_topics/3 returned #{inspect(resp)}"
+    end
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -2,32 +2,14 @@ defmodule Kafkaesque.Test.Helpers do
   def create_topics() do
     topic_configs = [
       %{
-        configs: [
-          %{
-            name: "cleanup.policy",
-            value: "compact"
-          },
-          %{
-            name: "confluent.value.schema.validation",
-            value: false
-          }
-        ],
+        configs: [],
         num_partitions: 1,
         replication_factor: 1,
         assignments: [],
         name: "integration_test_topic"
       },
       %{
-        configs: [
-          %{
-            name: "cleanup.policy",
-            value: "compact"
-          },
-          %{
-            name: "confluent.value.schema.validation",
-            value: true
-          }
-        ],
+        configs: [],
         num_partitions: 1,
         replication_factor: 1,
         assignments: [],


### PR DESCRIPTION

I have noticed [CI failures](https://github.com/v0idpwn/kafkaesque/actions), so I decided to fix that.

As seen on [kafka-client](https://github.com/happening-oss/kafka-client/) project, I think it's more convenient to have a `docker-compose.yml` file, and start its services in CI, rather than using Github Actions-native services. The advantage is that the same docker configuration can be started locally to run the tests.

Furthermore:
- The Postgres service in `docker-compose.yml` doesn't start automatically and is activated with a profile `with-postgres`. I imagine developers may often have native Postgres already running (at least that's the case for me).
- Kafka container uses the current latest official kafka broker image from confluence without zookeper. Kraft is currently the recommended way to run kafka, and should also be faster to boot.
- I extended sleep time in the test, as the test was failing on Github Actions with the previous value.

Example run on my fork:
https://github.com/mgibowski/kafkaesque/actions/runs/6707420753/job/18225921988