### PR TITLE
more flexible body handling

### DIFF
--- a/lib/kafkaesque.ex
+++ b/lib/kafkaesque.ex
@@ -50,7 +50,7 @@ defmodule Kafkaesque do
   use the library. See the documentation of the `Kafkaesque` module for more
   information.
   """
-  @spec publish(Ecto.Repo.t(), String.t(), term(), String.t(), String.t()) ::
+  @spec publish(Ecto.Repo.t(), String.t(), integer(), String.t(), term()) ::
           {:ok, Message.t()} | {:error, Ecto.Changeset.t()}
   def publish(repo, topic, partition, key, payload) do
     message = Message.new(topic, partition, key, payload)
@@ -118,7 +118,7 @@ defmodule Kafkaesque do
         Kafkaesque.publish(unquote(repo), topic, partition, key, payload)
       end
 
-      @spec encode(term()) :: String.t()
+      @spec encode(term()) :: term()
       def encode(body) do
         body
       end

--- a/lib/kafkaesque/clients/brod_client.ex
+++ b/lib/kafkaesque/clients/brod_client.ex
@@ -34,7 +34,8 @@ defmodule Kafkaesque.Clients.BrodClient do
   @impl Kafkaesque.Client
   def publish(%{brod_client_id: client_id, task_supervisor: task_supervisor}, messages) do
     # We pre-process the message bodies to avoid copying unecessary data to the task
-    message_batches = Enum.group_by(messages, &{&1.partition, &1.topic}, &{&1.key, &1.body})
+    message_batches =
+      Enum.group_by(messages, &{&1.partition, &1.topic}, & &1.body)
 
     task_results =
       task_supervisor

--- a/test/kafkaesque/message_test.exs
+++ b/test/kafkaesque/message_test.exs
@@ -22,7 +22,7 @@ defmodule Kafkaesque.MessageTest do
       key = 2
       partition = "notanumber"
 
-      assert %Ecto.Changeset{errors: [topic: _, partition: _, key: _, body: _]} =
+      assert %Ecto.Changeset{errors: [topic: _, partition: _, key: _]} =
                Message.new(topic, partition, key, body)
     end
   end

--- a/test/kafkaesque_test.exs
+++ b/test/kafkaesque_test.exs
@@ -5,22 +5,37 @@ defmodule KafkaesqueTest do
 
   describe "publish/4" do
     test "inserts valid messages" do
-      {:ok, %Kafkaesque.Message{}} = Kafkaesque.publish(Repo, "test_topic", 0, "", "content")
+      {:ok,
+       %Kafkaesque.Message{
+         key: "test_key",
+         body: "content",
+         state: :pending,
+         topic: "test_topic"
+       }} =
+        Kafkaesque.publish(Repo, "test_topic", 0, "test_key", "content")
+
+      {:ok,
+       %Kafkaesque.Message{
+         key: "test_key",
+         body: %{test: "content"},
+         state: :pending,
+         topic: "test_topic"
+       }} =
+        Kafkaesque.publish(Repo, "test_topic", 0, "test_key", %{test: "content"})
     end
 
     test "errors for invalid messages" do
       invalid_topic = 1
-      invalid_body = {1, 2}
       invalid_key = 2
       invalid_partition = "notanumber"
 
-      assert {:error, %Ecto.Changeset{errors: [topic: _, partition: _, key: _, body: _]}} =
+      assert {:error, %Ecto.Changeset{errors: [topic: _, partition: _, key: _]}} =
                Kafkaesque.publish(
                  Repo,
                  invalid_topic,
                  invalid_partition,
                  invalid_key,
-                 invalid_body
+                 %{}
                )
     end
   end


### PR DESCRIPTION
@v0idpwn Just wanted to get this up for a discussion. We have changes very similar to this to support our desired usage on a fork, but I wanted to see how you would recommend we could support more serializer types before I go in a specific direction. As an example, we should able to handle json, avro, protobuf, etc, and we can't really do that while casting body as a string. And ideally we'd update docs to show "if you want human readable entries in the database, do X, if not, do nothing"

Any guidance on the preferred implementation would be 💯, thanks! 